### PR TITLE
fix: correctly parse commit messages with multiple colons

### DIFF
--- a/src/parseTitle.test.ts
+++ b/src/parseTitle.test.ts
@@ -19,6 +19,17 @@ const data = [
       description: "description",
     },
   },
+  {
+    description: "correctly parse commit messages with multiple colons",
+    input:
+      "fix: `writing-mode: vertical-rl` bug on Safari, : to : has :: in it",
+    output: {
+      prefix: "fix",
+      scope: undefined,
+      description:
+        "`writing-mode: vertical-rl` bug on Safari, : to : has :: in it",
+    },
+  },
 ];
 
 data.forEach(({ description, input, output }) => {

--- a/src/parseTitle.ts
+++ b/src/parseTitle.ts
@@ -5,7 +5,7 @@ export const parseTitle = (
   scope?: string;
   description: string;
 } => {
-  const [label, description] = title.split(":");
+  const [label, description] = title.split(/:+(.*)/);
   const [prefix, scope] = label.split(/\(|\)/);
   return {
     prefix,


### PR DESCRIPTION
Closes #92 