### PR TITLE
refactor: throw an error if the format is invalid

### DIFF
--- a/src/parseTitle.test.ts
+++ b/src/parseTitle.test.ts
@@ -1,4 +1,4 @@
-import { parseTitle } from "./parseTitle";
+import { parseTitle, PARSE_TITLE_INVALID_FORMAT_ERROR } from "./parseTitle";
 
 const data = [
   {
@@ -25,4 +25,10 @@ data.forEach(({ description, input, output }) => {
   test(description, () => {
     expect(parseTitle(input)).toStrictEqual(output);
   });
+});
+
+test("throw an error if the format is invalid", () => {
+  expect(() => {
+    parseTitle("Feat #1223");
+  }).toThrow(PARSE_TITLE_INVALID_FORMAT_ERROR);
 });

--- a/src/parseTitle.ts
+++ b/src/parseTitle.ts
@@ -1,3 +1,6 @@
+export const PARSE_TITLE_INVALID_FORMAT_ERROR =
+  "The format of the commit message is invalid, follow conventional commits as `<type>[optional scope]: <description>`.";
+
 export const parseTitle = (
   title: string
 ): {
@@ -6,7 +9,13 @@ export const parseTitle = (
   description: string;
 } => {
   const [label, description] = title.split(":");
+
+  if (description === undefined) {
+    throw new Error(PARSE_TITLE_INVALID_FORMAT_ERROR);
+  }
+
   const [prefix, scope] = label.split(/\(|\)/);
+
   return {
     prefix,
     scope,


### PR DESCRIPTION
Closes #113 