### PR TITLE
fix: check validity of titles by running isValidTitle before parseTitle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ async function run() {
 
     const RELEASE_PREFIX = core.getInput("RELEASE_PREFIX");
 
+    if (isValidTitle(current.data.title) === false) {
+      throw new Error("This pull request is an invalid format.");
+    }
+
     if (RELEASE_PREFIX !== parseTitle(current.data.title).prefix) {
       core.warning(
         `This title prefix does not match the specified release prefix "${RELEASE_PREFIX}".`


### PR DESCRIPTION
Closes #126 

parse出来るかどうかだけを見ていたため、検知できないケースが存在した