### PR TITLE
refactor: パースされたprefixとscopeの両端にある空白を削除する

### DIFF
--- a/src/parseTitle.test.ts
+++ b/src/parseTitle.test.ts
@@ -30,6 +30,15 @@ const data = [
         "`writing-mode: vertical-rl` bug on Safari, : to : has :: in it",
     },
   },
+  {
+    description: "Release pull request",
+    input: " Release Note: 2023-01-01",
+    output: {
+      prefix: "Release Note",
+      scope: undefined,
+      description: "2023-01-01",
+    },
+  },
 ];
 
 data.forEach(({ description, input, output }) => {

--- a/src/parseTitle.ts
+++ b/src/parseTitle.ts
@@ -17,8 +17,8 @@ export const parseTitle = (
   const [prefix, scope] = label.split(/\(|\)/);
 
   return {
-    prefix,
-    scope,
+    prefix: prefix.trim(),
+    scope: scope?.trim(),
     description: description.trim(),
   };
 };


### PR DESCRIPTION
Closes #225 