### PR TITLE
chore: use node.js v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
-name: 'generate-release-notes-body-based-on-pull-requests'
-description: 'Generate Release notes body based on pull requests'
+name: "generate-release-notes-body-based-on-pull-requests"
+description: "Generate Release notes body based on pull requests"
 inputs:
   GITHUB_TOKEN:
-    description: 'Set GITHUB_TOKEN'
+    description: "Set GITHUB_TOKEN"
     required: true
   RELEASE_PREFIX:
-    description: 'Please specify the prefix to use for the title of Release pull request.'
-    default: 'Release Note'
+    description: "Please specify the prefix to use for the title of Release pull request."
+    default: "Release Note"
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"


### PR DESCRIPTION
この対応のためにバージョンをあげてもらうの虚無なので、壊れたりしなければパッチで上げる。
そもそもテストはNode.js v20で走らせているので問題ないはず。

Closes #254 