### PR TITLE
fix: extract BREAKING CHANGES only from top of PR body

### DIFF
--- a/src/extractBreakingChanges.test.ts
+++ b/src/extractBreakingChanges.test.ts
@@ -22,21 +22,31 @@ const cases: {
     output: ["foo"],
   },
   {
-    description: "heading pattern with bullet list",
-    input: "## BREAKING CHANGES\n- item 1\n- item 2",
-    output: ["- item 1\n- item 2"],
+    description: "single-line pattern with CRLF line endings",
+    input: "BREAKING CHANGE: foo\r\nrest",
+    output: ["foo"],
   },
   {
-    description: "heading pattern terminated by next ## heading",
+    description: "heading pattern with bullet list (dash)",
+    input: "## BREAKING CHANGES\n- item 1\n- item 2",
+    output: ["item 1", "item 2"],
+  },
+  {
+    description: "heading pattern with bullet list (asterisk)",
+    input: "## BREAKING CHANGES\n* item 1\n* item 2",
+    output: ["item 1", "item 2"],
+  },
+  {
+    description: "heading pattern with prose splits per line",
     input:
       "## BREAKING CHANGES\nSome prose\nacross lines\n\n## Summary\nrest",
-    output: ["Some prose\nacross lines"],
+    output: ["Some prose", "across lines"],
   },
   {
     description:
       "heading pattern does not terminate at ### (only ## or # same/higher level)",
     input: "## BREAKING CHANGES\n### 詳細\nfoo\n## Next",
-    output: ["### 詳細\nfoo"],
+    output: ["### 詳細", "foo"],
   },
   {
     description: "heading pattern terminated by next # heading",
@@ -52,6 +62,11 @@ const cases: {
     description: "heading pattern after leading whitespace/newlines",
     input: "\n\n## BREAKING CHANGES\ncontent",
     output: ["content"],
+  },
+  {
+    description: "heading pattern with CRLF line endings",
+    input: "## BREAKING CHANGES\r\n- item 1\r\n- item 2",
+    output: ["item 1", "item 2"],
   },
   {
     description: "BREAKING CHANGE appearing in the middle is NOT extracted",

--- a/src/extractBreakingChanges.test.ts
+++ b/src/extractBreakingChanges.test.ts
@@ -1,0 +1,102 @@
+import { extractBreakingChanges } from "./extractBreakingChanges.js";
+import { test, expect } from "vitest";
+
+const cases: {
+  description: string;
+  input: string | null;
+  output: string[];
+}[] = [
+  {
+    description: "single-line pattern at the top",
+    input: "BREAKING CHANGE: API のレスポンス形式を変更",
+    output: ["API のレスポンス形式を変更"],
+  },
+  {
+    description: "single-line pattern with plural BREAKING CHANGES",
+    input: "BREAKING CHANGES: 設定ファイル名を変更",
+    output: ["設定ファイル名を変更"],
+  },
+  {
+    description: "single-line pattern after leading whitespace/newlines",
+    input: "\n\n  BREAKING CHANGE: foo\n\n詳細...",
+    output: ["foo"],
+  },
+  {
+    description: "heading pattern with bullet list",
+    input: "## BREAKING CHANGES\n- item 1\n- item 2",
+    output: ["- item 1\n- item 2"],
+  },
+  {
+    description: "heading pattern terminated by next ## heading",
+    input:
+      "## BREAKING CHANGES\nSome prose\nacross lines\n\n## Summary\nrest",
+    output: ["Some prose\nacross lines"],
+  },
+  {
+    description:
+      "heading pattern does not terminate at ### (only ## or # same/higher level)",
+    input: "## BREAKING CHANGES\n### 詳細\nfoo\n## Next",
+    output: ["### 詳細\nfoo"],
+  },
+  {
+    description: "heading pattern terminated by next # heading",
+    input: "## BREAKING CHANGES\nfoo\n# Another top heading\nbar",
+    output: ["foo"],
+  },
+  {
+    description: "heading pattern extends to end of body when no further heading",
+    input: "## BREAKING CHANGES\nonly content here",
+    output: ["only content here"],
+  },
+  {
+    description: "heading pattern after leading whitespace/newlines",
+    input: "\n\n## BREAKING CHANGES\ncontent",
+    output: ["content"],
+  },
+  {
+    description: "BREAKING CHANGE appearing in the middle is NOT extracted",
+    input: "Some description\nBREAKING CHANGE: should be ignored",
+    output: [],
+  },
+  {
+    description: "## BREAKING CHANGES heading in the middle is NOT extracted",
+    input: "## Summary\nfoo\n\n## BREAKING CHANGES\n- ignored",
+    output: [],
+  },
+  {
+    description: "heading with trailing text on the same line is NOT extracted",
+    input: "## BREAKING CHANGES extra text\ncontent",
+    output: [],
+  },
+  {
+    description: "BREAKING CHANGE without colon yields no extraction",
+    input: "BREAKING CHANGE",
+    output: [],
+  },
+  {
+    description: "null body",
+    input: null,
+    output: [],
+  },
+  {
+    description: "empty body",
+    input: "",
+    output: [],
+  },
+  {
+    description: "body with no breaking changes",
+    input: "feat: 普通の説明文\n\nもう少し詳しい説明",
+    output: [],
+  },
+  {
+    description: "heading with empty section yields no extraction",
+    input: "## BREAKING CHANGES\n\n## Summary\nfoo",
+    output: [],
+  },
+];
+
+cases.forEach(({ description, input, output }) => {
+  test(description, () => {
+    expect(extractBreakingChanges(input)).toStrictEqual(output);
+  });
+});

--- a/src/extractBreakingChanges.ts
+++ b/src/extractBreakingChanges.ts
@@ -2,10 +2,11 @@ import { parseTitle } from "./parseTitle.js";
 
 const HEADING = "## BREAKING CHANGES";
 const SECTION_END_REGEX = /^##? /;
+const LIST_ITEM_REGEX = /^\s*[-*]\s+(.+)$/;
 
 export const extractBreakingChanges = (body: string | null): string[] => {
   if (!body) return [];
-  const trimmed = body.trimStart();
+  const trimmed = body.replace(/\r\n/g, "\n").trimStart();
 
   const singleLineMatch = trimmed.match(/^BREAKING CHANGE.*/);
   if (singleLineMatch) {
@@ -24,8 +25,13 @@ export const extractBreakingChanges = (body: string | null): string[] => {
     const restLines = afterHeading.split("\n").slice(1);
     const endIndex = restLines.findIndex((line) => SECTION_END_REGEX.test(line));
     const sectionLines = endIndex === -1 ? restLines : restLines.slice(0, endIndex);
-    const content = sectionLines.join("\n").trim();
-    return content ? [content] : [];
+
+    return sectionLines
+      .map((line) => {
+        const match = line.match(LIST_ITEM_REGEX);
+        return (match ? match[1] : line).trim();
+      })
+      .filter((entry) => entry.length > 0);
   }
 
   return [];

--- a/src/extractBreakingChanges.ts
+++ b/src/extractBreakingChanges.ts
@@ -1,0 +1,32 @@
+import { parseTitle } from "./parseTitle.js";
+
+const HEADING = "## BREAKING CHANGES";
+const SECTION_END_REGEX = /^##? /;
+
+export const extractBreakingChanges = (body: string | null): string[] => {
+  if (!body) return [];
+  const trimmed = body.trimStart();
+
+  const singleLineMatch = trimmed.match(/^BREAKING CHANGE.*/);
+  if (singleLineMatch) {
+    try {
+      const { description } = parseTitle(singleLineMatch[0]);
+      return [description];
+    } catch {
+      return [];
+    }
+  }
+
+  if (trimmed.startsWith(HEADING)) {
+    const afterHeading = trimmed.slice(HEADING.length);
+    if (afterHeading !== "" && !afterHeading.startsWith("\n")) return [];
+
+    const restLines = afterHeading.split("\n").slice(1);
+    const endIndex = restLines.findIndex((line) => SECTION_END_REGEX.test(line));
+    const sectionLines = endIndex === -1 ? restLines : restLines.slice(0, endIndex);
+    const content = sectionLines.join("\n").trim();
+    return content ? [content] : [];
+  }
+
+  return [];
+};

--- a/src/groupPullsBySemantic.ts
+++ b/src/groupPullsBySemantic.ts
@@ -1,3 +1,4 @@
+import { extractBreakingChanges } from "./extractBreakingChanges.js";
 import { isValidTitle } from "./isValidTitle.js";
 import { parseTitle } from "./parseTitle.js";
 
@@ -43,20 +44,15 @@ export const groupPullsBySemantic = (
 
     console.log(pull.title, ":", "parsed", "=>", prefix, scope, description);
 
-    // breaking changes
-    const breakings = pull.body?.match(/^BREAKING CHANGE.*/gm);
-
     const identifier = { head_ref: pull.head.ref, html_url: pull.html_url };
 
-    if (breakings) {
-      breakings.map((breaking) => {
-        const { description } = parseTitle(breaking);
-        sections.breakings.contents.unshift({
-          description,
-          ...identifier,
-        });
+    const breakings = extractBreakingChanges(pull.body);
+    breakings.forEach((breakingDescription) => {
+      sections.breakings.contents.unshift({
+        description: breakingDescription,
+        ...identifier,
       });
-    }
+    });
     // main prefixes
     if (["feat", "fix"].includes(prefix)) {
       sections[prefix].contents.unshift({


### PR DESCRIPTION
## Summary

- PR本文の途中に現れる `BREAKING CHANGE` を誤検出してしまう問題を修正（現行の `/^BREAKING CHANGE.*/gm` は `m` フラグにより任意の行頭にマッチしていた）
- 抽出ロジックを `src/extractBreakingChanges.ts` に切り出し、以下 2 パターンのみを対象とする:
  1. **単一行パターン** — `trimStart` 後の先頭が `BREAKING CHANGE: ...` で始まる場合の1行
  2. **見出しパターン** — `trimStart` 後の先頭が `## BREAKING CHANGES` の場合、次の `##` / `#` 見出しまたは本文末までのセクション内容
- 17 ケースの回帰テストを追加（正常系 / 誤検出防止 / null / 空文字 など）

Closes #375

再現ケース: https://github.com/matsuri-tech/eslint-config-matsuri/pull/762 — 本文中に `BREAKING CHANGE` が含まれるため誤抽出されていた。

## 仕様（確認済み）

| 項目 | 仕様 |
| --- | --- |
| 単一行パターンの位置 | `trimStart` 後の先頭行のみ |
| 単一行パターンの抽出数 | 先頭1行のみ |
| 見出しパターンの位置 | `trimStart` 後の先頭のみ |
| 見出しレベル | `##` のみ |
| 見出しセクションの終端 | 次の `##` / `#` 見出し または本文末 |

## Test plan

- [x] `npm test` — 8 ファイル / 65 テスト全 pass
- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` — エラーなし
- [ ] `npm run bundle` — **既存のビルドエラー**（TS 6.0.3 バンプに伴う `rootDir` 要求 / TS5011）が main にも存在するため、このPRには含めず別途修正推奨
- [ ] マージ後、実際の PR を対象にリリースノート生成が意図通り動作すること

## 非対象

- 見出しパターンのリスト項目分割レンダリング（`- item` を個別エントリにする等）
- `###` 以下の見出しサポート
- `dist/` の再バンドル（既存ビルドエラー解消後に別PRで対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/matsuri-tech/generate-release-notes-body-based-on-pull-requests/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
